### PR TITLE
Fixed datetime deserialization when using jsons.loads

### DIFF
--- a/jsons/_common_impl.py
+++ b/jsons/_common_impl.py
@@ -309,7 +309,7 @@ def loads(str_: str, cls: type = None, *args, **kwargs) -> object:
     :return: an instance of type ``cls`` or a dict if no ``cls`` is given.
     """
     obj = json.loads(str_, *args, **kwargs)
-    return load(obj, cls, **kwargs) if cls else obj
+    return load(obj, cls, **kwargs)
 
 
 def set_serializer(func: callable, cls: type, high_prio: bool = True,


### PR DESCRIPTION
Enabled deserializing datetimes in dicts using `jsons.loads()`.

The following code:

```python
import jsons
from datetime import datetime

jsons.loads(jsons.dumps({"a": datetime.now()}))
```

would return a dict containing the datetime as a string. By running the loaded dict through the `jsons.load()` method even if no class is provided, the datetime gets deserialized.