### PR TITLE
Implementation of strip_class_variables. More robust test cases.

### DIFF
--- a/jsons/serializers.py
+++ b/jsons/serializers.py
@@ -162,8 +162,7 @@ def default_object_serializer(obj: object,
     serializer functions.
     :return: a Python dict holding the values of ``obj``.
     """
-    obj_dict = obj.__dict__ if strip_properties and hasattr(obj, '__dict__') \
-        else _get_dict_from_obj(obj, strip_privates, **kwargs)
+    obj_dict = _get_dict_from_obj(obj, strip_privates, strip_properties, **kwargs)
     return default_dict_serializer(obj_dict,
                                    key_transformer=key_transformer,
                                    strip_nulls=strip_nulls,
@@ -172,11 +171,13 @@ def default_object_serializer(obj: object,
                                    **kwargs)
 
 
-def _get_dict_from_obj(obj, strip_privates, cls=None, *_, **__):
+def _get_dict_from_obj(obj, strip_privates, strip_properties, cls=None, *_, **__):
     excluded_elems = dir(JsonSerializable)
+    props = [n for n, v in obj.__class__.__dict__.items() if type(v) is property]
     return {attr: obj.__getattribute__(attr) for attr in dir(obj)
             if not attr.startswith('__')
             and not (strip_privates and attr.startswith('_'))
+            and not (strip_properties and attr in props)
             and attr != 'json'
             and not isinstance(obj.__getattribute__(attr), Callable)
             and (not cls or attr in cls.__slots__)

--- a/jsons/serializers.py
+++ b/jsons/serializers.py
@@ -160,7 +160,7 @@ def default_object_serializer(obj: object,
     :param strip_properties: if ``True`` the resulting dict will not contain
     values from @properties.
     :param strip_class_variables: if ``True`` the resulting dict will not
-    contain values class variables.
+    contain values from class variables.
     :param kwargs: any keyword arguments that are to be passed to the
     serializer functions.
     :return: a Python dict holding the values of ``obj``.

--- a/jsons/serializers.py
+++ b/jsons/serializers.py
@@ -194,9 +194,16 @@ def _get_dict_from_obj(obj, strip_privates, strip_properties,
 def _get_class_props(cls):
     props = []
     other_cls_vars = []
-    for n, v in cls.__dict__.items():
+    for n, v in _get_complete_class_dict(cls).items():
         props.append(n) if type(v) is property else other_cls_vars.append(n)
     return props, other_cls_vars
+
+
+def _get_complete_class_dict(cls):
+    cls_dict = {}
+    for parent_class in reversed(cls.mro()):
+        cls_dict.update(parent_class.__dict__)
+    return cls_dict
 
 
 # The following default key transformers can be used with the

--- a/jsons/serializers.py
+++ b/jsons/serializers.py
@@ -201,8 +201,9 @@ def _get_class_props(cls):
 
 def _get_complete_class_dict(cls):
     cls_dict = {}
-    for parent_class in reversed(cls.mro()):
-        cls_dict.update(parent_class.__dict__)
+    # Loop reversed so values of sub-classes override those of super-classes.
+    for cls_or_elder in reversed(cls.mro()):
+        cls_dict.update(cls_or_elder.__dict__)
     return cls_dict
 
 

--- a/jsons/serializers.py
+++ b/jsons/serializers.py
@@ -164,10 +164,12 @@ def default_object_serializer(obj: object,
     """
     obj_dict = obj.__dict__ if strip_properties and hasattr(obj, '__dict__') \
         else _get_dict_from_obj(obj, strip_privates, **kwargs)
-    kwargs['strip_properties'] = strip_properties  # add for possibly nested objects
-    return default_dict_serializer(obj_dict, key_transformer=key_transformer,
+    return default_dict_serializer(obj_dict,
+                                   key_transformer=key_transformer,
                                    strip_nulls=strip_nulls,
-                                   strip_privates=strip_privates, **kwargs)
+                                   strip_privates=strip_privates,
+                                   strip_properties=strip_properties,
+                                   **kwargs)
 
 
 def _get_dict_from_obj(obj, strip_privates, cls=None, *_, **__):

--- a/jsons/serializers.py
+++ b/jsons/serializers.py
@@ -164,6 +164,7 @@ def default_object_serializer(obj: object,
     """
     obj_dict = obj.__dict__ if strip_properties and hasattr(obj, '__dict__') \
         else _get_dict_from_obj(obj, strip_privates, **kwargs)
+    kwargs['strip_properties'] = strip_properties  # add for possibly nested objects
     return default_dict_serializer(obj_dict, key_transformer=key_transformer,
                                    strip_nulls=strip_nulls,
                                    strip_privates=strip_privates, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.rst', 'r') as fh:
     long_description = fh.read()
 
 setup(name='jsons',
-      version='0.5.5',
+      version='0.6.0',
       author='Ramon Hagenaars',
       author_email='ramon.hagenaars@gmail.com',
       description='For serializing Python objects to JSON (dicts) and back',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.rst', 'r') as fh:
     long_description = fh.read()
 
 setup(name='jsons',
-      version='0.5.4',
+      version='0.5.5',
       author='Ramon Hagenaars',
       author_email='ramon.hagenaars@gmail.com',
       description='For serializing Python objects to JSON (dicts) and back',

--- a/test_jsons.py
+++ b/test_jsons.py
@@ -102,13 +102,24 @@ class TestJsons(TestCase):
         expected = ['2018-07-08T21:34:00Z']
         self.assertEqual(dumped, expected)
 
-    class AllDumpable:
+    class ParentDumpable:
+        _par_c = 10
+
+        def __init__(self):
+            self.par_v = None
+
+        @property
+        def par_p(self):
+            return 12
+
+    class AllDumpable(ParentDumpable):
         c = 1
         _c = 2
         c_n = None
         _c_n = None
 
         def __init__(self, child=None):
+            super().__init__()
             self.child = child
             self.v = 3
             self._v = 4
@@ -133,7 +144,8 @@ class TestJsons(TestCase):
 
     def test_dump_object(self):
         obj = self.AllDumpable(self.AllDumpable())
-        exp = {'c': 1, '_c': 2, 'c_n': None, '_c_n': None,
+        exp = {'_par_c': 10, 'par_v': None, 'par_p': 12,
+               'c': 1, '_c': 2, 'c_n': None, '_c_n': None,
                'child': None, 'v': 3, '_v': 4, 'v_n': None, '_v_n': None,
                'p': 5, '_p': 5, 'p_n': None, '_p_n': None}
         exp['child'] = exp.copy()
@@ -142,7 +154,8 @@ class TestJsons(TestCase):
 
     def test_dump_object_strip_properties(self):
         obj = self.AllDumpable(self.AllDumpable())
-        exp = {'c': 1, '_c': 2, 'c_n': None, '_c_n': None,
+        exp = {'_par_c': 10, 'par_v': None,
+               'c': 1, '_c': 2, 'c_n': None, '_c_n': None,
                'child': None, 'v': 3, '_v': 4, 'v_n': None, '_v_n': None}
         exp['child'] = exp.copy()
         dump = jsons.dump(obj, strip_properties=True)
@@ -150,7 +163,8 @@ class TestJsons(TestCase):
 
     def test_dump_object_strip_nulls(self):
         obj = self.AllDumpable(self.AllDumpable())
-        exp = {'c': 1, '_c': 2, 'child': None, 'v': 3, '_v': 4, 'p': 5, '_p': 5}
+        exp = {'_par_c': 10, 'par_p': 12,
+               'c': 1, '_c': 2, 'child': None, 'v': 3, '_v': 4, 'p': 5, '_p': 5}
         exp['child'] = exp.copy()
         exp['child'].pop('child')  # child shouldn't have None child
         dump = jsons.dump(obj, strip_nulls=True)
@@ -158,7 +172,8 @@ class TestJsons(TestCase):
 
     def test_dump_object_strip_privates(self):
         obj = self.AllDumpable(self.AllDumpable())
-        exp = {'c': 1, 'c_n': None,
+        exp = {'par_v': None, 'par_p': 12,
+               'c': 1, 'c_n': None,
                'child': None, 'v': 3, 'v_n': None, 'p': 5, 'p_n': None}
         exp['child'] = exp.copy()
         dump = jsons.dump(obj, strip_privates=True)
@@ -166,7 +181,8 @@ class TestJsons(TestCase):
 
     def test_dump_object_strip_class_variables(self):
         obj = self.AllDumpable(self.AllDumpable())
-        exp = {'child': None, 'v': 3, '_v': 4, 'v_n': None, '_v_n': None,
+        exp = {'par_v': None, 'par_p': 12,
+               'child': None, 'v': 3, '_v': 4, 'v_n': None, '_v_n': None,
                'p': 5, '_p': 5, 'p_n': None, '_p_n': None}
         exp['child'] = exp.copy()
         dump = jsons.dump(obj, strip_class_variables=True)

--- a/test_jsons.py
+++ b/test_jsons.py
@@ -133,14 +133,17 @@ class TestJsons(TestCase):
 
     def test_dump_object(self):
         obj = self.AllDumpable(self.AllDumpable())
-        exp = {'c': 1, '_c': 2, 'c_n': None, '_c_n': None, 'child': None, 'v': 3, '_v': 4, 'v_n': None, '_v_n': None, 'p': 5, '_p': 5, 'p_n': None, '_p_n': None}
+        exp = {'c': 1, '_c': 2, 'c_n': None, '_c_n': None,
+               'child': None, 'v': 3, '_v': 4, 'v_n': None, '_v_n': None,
+               'p': 5, '_p': 5, 'p_n': None, '_p_n': None}
         exp['child'] = exp.copy()
         dump = jsons.dump(obj)
         self.assertDictEqual(exp, dump)
 
     def test_dump_object_strip_properties(self):
         obj = self.AllDumpable(self.AllDumpable())
-        exp = {'c': 1, '_c': 2, 'c_n': None, '_c_n': None, 'child': None, 'v': 3, '_v': 4, 'v_n': None, '_v_n': None}
+        exp = {'c': 1, '_c': 2, 'c_n': None, '_c_n': None,
+               'child': None, 'v': 3, '_v': 4, 'v_n': None, '_v_n': None}
         exp['child'] = exp.copy()
         dump = jsons.dump(obj, strip_properties=True)
         self.assertDictEqual(exp, dump)
@@ -155,9 +158,18 @@ class TestJsons(TestCase):
 
     def test_dump_object_strip_privates(self):
         obj = self.AllDumpable(self.AllDumpable())
-        exp = {'c': 1, 'c_n': None, 'child': None, 'v': 3, 'v_n': None, 'p': 5, 'p_n': None}
+        exp = {'c': 1, 'c_n': None,
+               'child': None, 'v': 3, 'v_n': None, 'p': 5, 'p_n': None}
         exp['child'] = exp.copy()
         dump = jsons.dump(obj, strip_privates=True)
+        self.assertDictEqual(exp, dump)
+
+    def test_dump_object_strip_class_variables(self):
+        obj = self.AllDumpable(self.AllDumpable())
+        exp = {'child': None, 'v': 3, '_v': 4, 'v_n': None, '_v_n': None,
+               'p': 5, '_p': 5, 'p_n': None, '_p_n': None}
+        exp['child'] = exp.copy()
+        dump = jsons.dump(obj, strip_class_variables=True)
         self.assertDictEqual(exp, dump)
 
     def test_dump_with_slots(self):

--- a/test_jsons.py
+++ b/test_jsons.py
@@ -117,6 +117,9 @@ class TestJsons(TestCase):
 
     def test_dump_object_properties(self):
         class A:
+            def __init__(self):
+                self.b = B()
+
             @property
             def x(self):
                 return 123
@@ -124,9 +127,14 @@ class TestJsons(TestCase):
             def y(self):
                 return 456  # Not to be serialized.
 
+        class B:
+            @property
+            def c(self):
+                return 'bananas'  # To be also stripped.
+
         a = A()
-        self.assertDictEqual({'x': 123}, jsons.dump(a))
-        self.assertDictEqual({}, jsons.dump(a, strip_properties=True))
+        self.assertDictEqual({'x': 123, 'b': {'c': 'bananas'}}, jsons.dump(a))
+        self.assertDictEqual({'b': {}}, jsons.dump(a, strip_properties=True))
 
     def test_dump_object_strip_nulls(self):
         class A:

--- a/test_jsons.py
+++ b/test_jsons.py
@@ -144,7 +144,6 @@ class TestJsons(TestCase):
         exp['child'] = exp.copy()
         dump = jsons.dump(obj, strip_properties=True)
         self.assertDictEqual(exp, dump)
-        # TODO all class variable also stripped
 
     def test_dump_object_strip_nulls(self):
         obj = self.AllDumpable(self.AllDumpable())


### PR DESCRIPTION
(Sorry about the previous PR I closed)

Tell me if it makes sense to provide option to strip class variables. I find it pretty useful in my application. This current implementation is able to handle also class inheritance.

I also made only one class for obj dump tests. They are maybe a bit less readable now, but more robust IMHO.

This PR also includes the previous one #5.