### PR TITLE
Fix unspecified List deserialization

### DIFF
--- a/jsons/deserializers/default_list.py
+++ b/jsons/deserializers/default_list.py
@@ -1,4 +1,5 @@
 from jsons._main_impl import load
+from typing import TypeVar
 
 
 def default_list_deserializer(obj: list, cls: type = None, **kwargs) -> list:
@@ -10,6 +11,6 @@ def default_list_deserializer(obj: list, cls: type = None, **kwargs) -> list:
     :return: a deserialized list instance.
     """
     cls_ = None
-    if cls and hasattr(cls, '__args__'):
+    if cls and hasattr(cls, '__args__') and not isinstance(cls.__args__[0], TypeVar):
         cls_ = cls.__args__[0]
     return [load(x, cls_, **kwargs) for x in obj]

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import List
 from unittest import TestCase
 import jsons
 
@@ -17,3 +18,11 @@ class TestList(TestCase):
         list_ = [1, 2, 3, [4, 5, [dat]]]
         expectation = [1, 2, 3, [4, 5, ['2018-07-08T21:34:00Z']]]
         self.assertEqual(list_, jsons.load(expectation))
+
+    def test_load_explicit_specified_list(self):
+        list_ = [1, 2, 3]
+        self.assertEqual(list_, jsons.load(list_, List[int]))
+
+    def test_load_explicit_unspecified_list(self):
+        list_ = [1, 2, 3]
+        self.assertEqual(list_, jsons.load(list_, List))


### PR DESCRIPTION
This code:

```
import jsons
from typing import List

jsons.load(["Hello", "World"], List)
```

would fail with a: `TypeError: 'NoneType' object is not callable`.

This is because the bare List type contains an `__args__[0]` which is a `TypeVar`, which is not callable when deserializing.

This pull request fixed that by checking if the `__args__[0]` is actually usable and not just a bare `TypeVar`.