### PR TITLE
Imports: collections -> collections.abc [#40]

### DIFF
--- a/jsons/deserializers/default_mapping.py
+++ b/jsons/deserializers/default_mapping.py
@@ -1,4 +1,4 @@
-from collections import Mapping
+from collections.abc import Mapping
 from typing import Mapping as MappingType
 from jsons._common_impl import get_naked_class
 from jsons.deserializers import default_dict_deserializer

--- a/jsons/serializers/default_iterable.py
+++ b/jsons/serializers/default_iterable.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 from jsons._main_impl import dump
 
 


### PR DESCRIPTION
Update imports to import ABCs from `collections.abc` instead of `collections` [deprecated in 3.8].

Resolves #40 