### PR TITLE
Dumping a tuple with an ellipsis now works in strict mode as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ list_of_tuples = jsons.load(some_dict, List[Tuple[AClass, AnotherClass]])
 
 ## Recent updates
 
+### 1.1.2
+
+- Bugfix: Dumping a tuple with ellipsis failed in strict mode.
+
 ### 1.1.1
 
   - Feature: Added a serializer for ``Union`` types.
@@ -120,11 +124,7 @@ list_of_tuples = jsons.load(some_dict, List[Tuple[AClass, AnotherClass]])
 
 ### 0.10.2
 
-  - Bugfix: Loading `Dict[K, V]` did not parse `K`.
-
-### 0.10.1
-
-  - Change: Correction of the type hints of `load`, `loads`, `loadb`.
+  - Bugfix: Loading `Dict[K, V]` did not parse `K
 
 
 ## Contributors

--- a/jsons/serializers/default_iterable.py
+++ b/jsons/serializers/default_iterable.py
@@ -35,7 +35,6 @@ def default_iterable_serializer(
     kwargs_.pop('_store_cls', None)
     if strict:
         cls_ = determine_cls(obj, cls)
-        # cls_ = cls or get_type(obj)  # Get the List[T] type from the instance.
         subclasses = _get_subclasses(obj, cls_)
     else:
         subclasses = _get_subclasses(obj, None)

--- a/jsons/serializers/default_primitive.py
+++ b/jsons/serializers/default_primitive.py
@@ -9,7 +9,7 @@ def default_primitive_serializer(obj: object,
     """
     Serialize a primitive; simply return the given ``obj``.
     :param obj: the primitive.
-    :param _: not used.
+    :param cls: the type of ``obj``.
     :return: ``obj``.
     """
     result = obj

--- a/jsons/serializers/default_tuple.py
+++ b/jsons/serializers/default_tuple.py
@@ -1,19 +1,31 @@
-from typing import Union
+from typing import Union, Optional
+
+from typish import get_args
+
+from jsons._compatibility_impl import tuple_with_ellipsis
 from jsons._dump_impl import dump
 from jsons.serializers.default_iterable import default_iterable_serializer
 
 
-def default_tuple_serializer(obj: tuple, **kwargs) -> Union[list, dict]:
+def default_tuple_serializer(obj: tuple,
+                             cls: Optional[type] = None,
+                             **kwargs) -> Union[list, dict]:
     """
     Serialize the given ``obj`` to a list of serialized objects.
     :param obj: the tuple that is to be serialized.
+    :param cls: the type of the ``obj``.
     :param kwargs: any keyword arguments that may be given to the serialization
     process.
     :return: a list of which all elements are serialized.
     """
     if hasattr(obj, '_fields'):
         return default_namedtuple_serializer(obj, **kwargs)
-    return default_iterable_serializer(obj, **kwargs)
+
+    cls_ = cls
+    if cls and tuple_with_ellipsis(cls):
+        cls_ = (get_args(cls)[0],) * len(obj)
+
+    return default_iterable_serializer(obj, cls_, **kwargs)
 
 
 def default_namedtuple_serializer(obj: tuple, **kwargs) -> dict:

--- a/jsons/serializers/default_tuple.py
+++ b/jsons/serializers/default_tuple.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional
+from typing import Union, Optional, Tuple
 
 from typish import get_args
 
@@ -23,7 +23,7 @@ def default_tuple_serializer(obj: tuple,
 
     cls_ = cls
     if cls and tuple_with_ellipsis(cls):
-        cls_ = (get_args(cls)[0],) * len(obj)
+        cls_ = Tuple[(get_args(cls)[0],) * len(obj)]
 
     return default_iterable_serializer(obj, cls_, **kwargs)
 

--- a/tests/test_tuple.py
+++ b/tests/test_tuple.py
@@ -22,9 +22,12 @@ class TestTuple(TestCase):
         expected = {
             'x': ['abc', 'def']
         }
-        dumped = jsons.dump(A(('abc', 'def')), strict=True)
 
-        self.assertDictEqual(expected, dumped)
+        dumped1 = jsons.dump(A(('abc', 'def')), strict=True)
+        dumped2 = jsons.dump(A(('abc', 'def')), strict=False)
+
+        self.assertDictEqual(expected, dumped1)
+        self.assertDictEqual(expected, dumped2)
 
     def test_dump_namedtuple(self):
         T = namedtuple('T', ['x', 'y'])

--- a/tests/test_tuple.py
+++ b/tests/test_tuple.py
@@ -14,6 +14,18 @@ class TestTuple(TestCase):
         self.assertEqual([1, 2, 3, [4, 5, ['2018-07-08T21:34:00Z']]],
                          jsons.dump(tup))
 
+    def test_dump_tuple_with_ellipsis(self):
+        class A:
+            def __init__(self, x: Tuple[str, ...]):
+                self.x = x
+
+        expected = {
+            'x': ['abc', 'def']
+        }
+        dumped = jsons.dump(A(('abc', 'def')), strict=True)
+
+        self.assertDictEqual(expected, dumped)
+
     def test_dump_namedtuple(self):
         T = namedtuple('T', ['x', 'y'])
         t = T(1, 2)


### PR DESCRIPTION
Fixes #85: dumping a tuple with ellipsis failed in strict mode.