### PR TITLE
Correct variable name in docs index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,7 +57,7 @@ And to deserialize, just do:
 
 .. code:: python
 
-   instance = jsons.load(loaded, Car)
+   instance = jsons.load(dumped, Car)
 
 Type hints for the win!
 


### PR DESCRIPTION
I believe the variable should read `dumped`, instead of `loaded` (which for the reader, does not exist yet).