### PR TITLE
Bypass the Union types when the object can be None

### DIFF
--- a/jsons/serializers/default_union.py
+++ b/jsons/serializers/default_union.py
@@ -1,5 +1,5 @@
 from typing import Union
-from jsons._common_impl import get_class_name
+from jsons._common_impl import get_class_name, NoneType
 from jsons._compatibility_impl import get_union_params
 from jsons._dump_impl import dump
 from jsons.exceptions import JsonsError, SerializationError
@@ -16,7 +16,14 @@ def default_union_serializer(obj: object, cls: Union, **kwargs) -> object:
     :return: An object of the first type of the Union that could be
     serialized successfully.
     """
-    for sub_type in get_union_params(cls):
+    sub_types = get_union_params(cls)
+
+    # Cater for Optional[...]/Union[None, ...] first to avoid blindly
+    # string-ifying None in later serializers.
+    if obj is None and NoneType in sub_types:
+        return obj
+
+    for sub_type in sub_types:
         try:
             return dump(obj, sub_type, **kwargs)
         except JsonsError:

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,4 +1,6 @@
+import dataclasses
 import datetime
+import uuid
 from typing import Optional, Union
 from unittest import TestCase
 
@@ -11,7 +13,7 @@ from jsons import (
 
 
 class TestUnion(TestCase):
-    def test_dump_optional(self):
+    def test_dump_optional_primitive(self):
 
         class C:
             def __init__(self, x: Optional[str]):
@@ -21,6 +23,50 @@ class TestUnion(TestCase):
         dumped = jsons.dump(C('42'))
 
         self.assertDictEqual(expected, dumped)
+
+    def test_dump_optional_uuid(self):
+        class C:
+            def __init__(self, x: Optional[uuid.UUID]):
+                self.x = x
+
+        expected = {'x': '00000000-0000-0000-0000-000000000000'}
+        dumped = jsons.dump(C(uuid.UUID(int=0)))
+
+        self.assertDictEqual(expected, dumped)
+
+    def test_dump_optional_class_primitive(self):
+        class C:
+            x: Optional[int]
+
+            def __init__(self, x):
+                self.x = x
+
+        expected = {'x': 42}
+        dumped = jsons.dump(C(42))
+
+        self.assertDictEqual(expected, dumped)
+
+        expected2 = {'x': None}
+        dumped2 = jsons.dump(C(None))
+
+        self.assertDictEqual(expected2, dumped2)
+
+    def test_dump_optional_class_uuid(self):
+        class C:
+            x: Optional[uuid.UUID]
+
+            def __init__(self, x):
+                self.x = x
+
+        expected = {'x': '00000000-0000-0000-0000-000000000000'}
+        dumped = jsons.dump(C(uuid.UUID(int=0)))
+
+        self.assertDictEqual(expected, dumped)
+
+        expected2 = {'x': None}
+        dumped2 = jsons.dump(C(None))
+
+        self.assertDictEqual(expected2, dumped2)
 
     def test_dump_union(self):
 


### PR DESCRIPTION
When an object is allowed to be None (i.e. Union[..., None] or
Optional[...]), and it *is* None, bypass any upcoming serializers
and return None.

This fixes non-primitive serializers that would string-ify the
object (`str(obj)`) and yield `'None'`.

Fixes: #120