### PR TITLE
strip_microseconds should be False by default

### DIFF
--- a/jsons/serializers/default_datetime.py
+++ b/jsons/serializers/default_datetime.py
@@ -6,7 +6,7 @@ from jsons._datetime_impl import to_str, RFC3339_DATETIME_PATTERN
 
 def default_datetime_serializer(obj: datetime,
                                 *,
-                                strip_microseconds: Optional[bool] = True,
+                                strip_microseconds: Optional[bool] = False,
                                 **kwargs) -> str:
     """
     Serialize the given datetime instance to a string. It uses the RFC3339

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -52,13 +52,13 @@ class TestDatetime(TestCase):
         d = datetime.datetime(year=2018, month=7, day=8, hour=21, minute=34,
                               second=10, microsecond=123456,
                               tzinfo=datetime.timezone.utc)
-        dumped = jsons.dump(d)
+        dumped = jsons.dump(d, strip_microseconds=True)
         self.assertEqual('2018-07-08T21:34:10Z', dumped)
 
     def test_dump_datetime_with_microseconds(self):
         d = datetime.datetime(year=2018, month=7, day=8, hour=21, minute=34,
                               microsecond=123456, tzinfo=datetime.timezone.utc)
-        dumped = jsons.dump(d, strip_microseconds=False)
+        dumped = jsons.dump(d)
         self.assertEqual('2018-07-08T21:34:00.123456Z', dumped)
 
     def test_dump_datetime_with_tz(self):


### PR DESCRIPTION
The `strip_microseconds` parameter of the serializer should be `False` by default. Otherwise, serializing and deserializing any object containing a `datetime` will result in a deserialized object different from the original.

Consider the following example:
```python
from dataclasses import dataclass
from datetime import datetime, timezone

import jsons


@dataclass
class Container:
    time: datetime


if __name__ == '__main__':
    obj = Container(time=datetime.now(tz=timezone.utc))

    serialized_without_microseconds = jsons.dumps(obj)
    serialized_with_microseconds = jsons.dumps(obj, strip_microseconds=False)

    deser_without_microseconds = jsons.loads(serialized_without_microseconds, cls=Container)
    deser_with_microseconds = jsons.loads(serialized_with_microseconds, cls=Container)

    print(f"{(obj == deser_without_microseconds)=}")
    print(f"{(obj == deser_with_microseconds)=}")
```

It will print:
```
(obj == deser_without_microseconds)=False
(obj == deser_with_microseconds)=True
```