### PR TITLE
Avoid hashed keys when json-key-compatible serializer is set for key type, avoid errors on strict with hashed keys

### DIFF
--- a/jsons/serializers/default_dict.py
+++ b/jsons/serializers/default_dict.py
@@ -1,4 +1,4 @@
-from typing import Optional, Callable, Dict, Tuple
+from typing import Callable, Dict, Optional, Tuple
 
 from jsons._common_impl import JSON_KEYS
 from jsons._dump_impl import dump
@@ -71,10 +71,15 @@ def _store_and_hash(
         # Apparently key is not a valid json key value. Since it got into
         # a Python dict without crashing, it must be hashable.
         obj_ = {**obj}
-        key_hash = hash(key)
-        if '-keys' not in obj_:
-            obj_['-keys'] = {}
+
+        # However there may be a serializer set for it
         dumped_key = dump(key, **kwargs)
-        obj_['-keys'][key_hash] = dumped_key
-        result = (obj_, key_hash)
+        if not any(issubclass(type(dumped_key), json_key) for json_key in JSON_KEYS):
+            key_hash = hash(key)
+            if '-keys' not in obj_:
+                obj_['-keys'] = {}
+            obj_['-keys'][key_hash] = dumped_key
+            result = (obj_, key_hash)
+        else:
+            result = (obj_, dumped_key)
     return result

--- a/tests/test_dict_hashkey.py
+++ b/tests/test_dict_hashkey.py
@@ -5,10 +5,7 @@ from unittest import TestCase
 import jsons
 
 
-class Foo(NamedTuple):
-    a: int
-    b: int
-    c: int
+Foo = NamedTuple('Foo', [('a', int), ('b', int), ('c', int)])
 
 
 @dataclass

--- a/tests/test_dict_hashkey.py
+++ b/tests/test_dict_hashkey.py
@@ -15,13 +15,6 @@ class D:
     def __eq__(self, other):
         return self.a == other.a and self.b == other.b
 
-    def __init__(self, a: int, b: int):
-        self.a = a
-        self.b = b
-
-    def __eq__(self, other):
-        return self.a == other.a and self.b == other.b
-
 
 class TestDict(TestCase):
     def tearDown(cls):
@@ -41,7 +34,7 @@ class TestDict(TestCase):
         jsons.set_serializer(foo_serializer, Foo,  True)
         jsons.set_deserializer(foo_deserializer, Foo,  True)
 
-        bar: Dict[Foo, D] = {Foo(1, 2, 3): D(a=42, b=39)}
+        bar = {Foo(1, 2, 3): D(a=42, b=39)}
         dumped = jsons.dump(bar, cls=Dict[Foo, D],
                             strict=True,
                             strip_privates=True,
@@ -56,7 +49,7 @@ class TestDict(TestCase):
         self.assertEqual(loaded, bar)
 
     def test_dict_hashkey(self):
-        bar: Dict[Foo, D] = {Foo(1, 2, 3): D(a=42, b=39)}
+        bar = {Foo(1, 2, 3): D(a=42, b=39)}
         dumped = jsons.dump(bar, cls=Dict[Foo, D],
                             strict=True,
                             strip_privates=True,

--- a/tests/test_dict_hashkey.py
+++ b/tests/test_dict_hashkey.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Dict, NamedTuple
 from unittest import TestCase
 
@@ -9,8 +8,12 @@ Foo = NamedTuple('Foo', [('a', int), ('b', int), ('c', int)])
 
 
 class D:
-    a: int
-    b: int
+    def __init__(self, a: int, b: int):
+        self.a = a
+        self.b = b
+
+    def __eq__(self, other):
+        return self.a == other.a and self.b == other.b
 
     def __init__(self, a: int, b: int):
         self.a = a

--- a/tests/test_dict_hashkey.py
+++ b/tests/test_dict_hashkey.py
@@ -8,10 +8,16 @@ import jsons
 Foo = NamedTuple('Foo', [('a', int), ('b', int), ('c', int)])
 
 
-@dataclass
 class D:
     a: int
     b: int
+
+    def __init__(self, a: int, b: int):
+        self.a = a
+        self.b = b
+
+    def __eq__(self, other):
+        return self.a == other.a and self.b == other.b
 
 
 class TestDict(TestCase):

--- a/tests/test_dict_hashkey.py
+++ b/tests/test_dict_hashkey.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+from typing import Dict, NamedTuple
+from unittest import TestCase
+
+import jsons
+
+
+class Foo(NamedTuple):
+    a: int
+    b: int
+    c: int
+
+
+@dataclass
+class D:
+    a: int
+    b: int
+
+
+class TestDict(TestCase):
+    def tearDown(cls):
+        jsons.set_serializer(jsons.default_primitive_serializer, Foo)
+        jsons.set_deserializer(jsons.default_string_deserializer, Foo)
+
+    def test_dict_hashkey_with_serializer(self):
+        def foo_serializer(obj, **kwargs):
+            return "{},{},{}".format(obj.a, obj.b, obj.c)
+
+        def foo_deserializer(obj, cls, **kwargs):
+            res = obj.split(',')
+            return Foo(a = int(res[0]),
+                       b = int(res[1]),
+                       c = int(res[2]))
+
+        jsons.set_serializer(foo_serializer, Foo,  True)
+        jsons.set_deserializer(foo_deserializer, Foo,  True)
+
+        bar: Dict[Foo, D] = {Foo(1, 2, 3): D(a=42, b=39)}
+        dumped = jsons.dump(bar, cls=Dict[Foo, D],
+                            strict=True,
+                            strip_privates=True,
+                            strip_properties=True,
+                            use_enum_name = True)
+        self.assertEqual(dumped, {'1,2,3': {"a": 42, "b": 39}})
+        loaded = jsons.load(dumped, cls=Dict[Foo, D],
+                            strict=True,
+                            strip_privates=True,
+                            strip_properties=True,
+                            use_enum_name = True)
+        self.assertEqual(loaded, bar)
+
+    def test_dict_hashkey(self):
+        bar: Dict[Foo, D] = {Foo(1, 2, 3): D(a=42, b=39)}
+        dumped = jsons.dump(bar, cls=Dict[Foo, D],
+                            strict=True,
+                            strip_privates=True,
+                            strip_properties=True,
+                            use_enum_name = True)
+        loaded = jsons.load(dumped, cls=Dict[Foo, D],
+                            strict=True,
+                            strip_privates=True,
+                            strip_properties=True,
+                            use_enum_name = True)
+        self.assertEqual(loaded, bar)


### PR DESCRIPTION
For

```
class Foo(NamedTuple):
    a: int
    b: int
    c: int


@dataclass
class D:
    a: int
    b: int


bar: Dict[Foo, D] = {Foo(1, 2, 3): D(a=42, b=39)}
dumped = jsons.dump(
    bar, cls=Dict[Foo, D],
    strict=True,
    strip_privates=True,
    strip_properties=True,
    use_enum_name = True)
loaded = jsons.load(
    dumped, cls=Dict[Foo, D],
    strict=True,
    strip_privates=True,
    strip_properties=True,
    use_enum_name = True)
```

jsons would previously crash on the load


```
class Foo(NamedTuple):
    a: int
    b: int
    c: int


@dataclass
class D:
    a: int
    b: int


def foo_serializer(obj, **kwargs):
    return "{},{},{}".format(obj.a, obj.b, obj.c)

def foo_deserializer(obj, cls, **kwargs):
    res = obj.split(',')
    return Foo(
        a = int(res[0]),
        b = int(res[1]),
        c = int(res[2]))

jsons.set_serializer(foo_serializer, Foo,  True)
jsons.set_deserializer(foo_deserializer, Foo,  True)

bar: Dict[Foo, D] = {Foo(1, 2, 3): D(a=42, b=39)}
dumped = jsons.dump(
    bar, cls=Dict[Foo, D],
    strict=True,
    strip_privates=True,
    strip_properties=True,
    use_enum_name = True)
loaded = jsons.load(
    dumped, cls=Dict[Foo, D],
    strict=True,
    strip_privates=True,
    strip_properties=True,
    use_enum_name = True)
```

would crash on load with strict mode and without would still use hashed keys despite the serialized key being json compatible.

This change corrects both and determines whether key hashing is required per key.