### PR TITLE
Serialize IntEnum by name if use_enum_name is True

### DIFF
--- a/jsons/__init__.py
+++ b/jsons/__init__.py
@@ -88,7 +88,7 @@ Alternatively, you can make use of the `JsonSerializable` class.
 from collections.abc import Mapping
 from datetime import datetime, date, time, timezone, timedelta
 from decimal import Decimal
-from enum import Enum
+from enum import Enum, IntEnum
 from pathlib import PurePath
 from typing import Union, List, Tuple, Iterable, Optional, DefaultDict, Dict
 from uuid import UUID
@@ -291,6 +291,7 @@ set_serializer(default_uuid_serializer, UUID)
 set_serializer(default_decimal_serializer, Decimal)
 set_serializer(default_union_serializer, (Union, Optional))
 set_serializer(default_path_serializer, PurePath)
+set_serializer(default_enum_serializer, IntEnum)  # must be after primitive_serializer
 
 set_deserializer(default_list_deserializer, (list, List))
 set_deserializer(default_tuple_deserializer, (tuple, Tuple))
@@ -312,6 +313,7 @@ set_deserializer(default_uuid_deserializer, UUID)
 set_deserializer(default_complex_deserializer, complex)
 set_deserializer(default_decimal_deserializer, Decimal)
 set_deserializer(default_path_deserializer, PurePath)
+set_deserializer(default_enum_deserializer, IntEnum)  # must be after primitive_deserializer
 
 if default_zone_info_serializer and default_zone_info_deserializer:
     from zoneinfo import ZoneInfo

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, IntEnum
 from unittest import TestCase
 
 import jsons
@@ -27,3 +27,26 @@ class TestEnum(TestCase):
             self.assertEqual(E.y, jsons.load(2, E, use_enum_name=True))
         with self.assertRaises(DeserializationError):
             self.assertEqual(E.y, jsons.load('y', E, use_enum_name=False))
+
+    def test_dump_intenum(self):
+        class IE(IntEnum):
+            x = 1
+            y = 2
+
+        self.assertEqual('x', jsons.dump(IE.x))
+        self.assertEqual(2, jsons.dump(IE.y, use_enum_name=False))
+
+    def test_load_intenum(self):
+        class IE(IntEnum):
+            x = 1
+            y = 2
+
+        self.assertEqual(IE.x, jsons.load('x', IE))
+        self.assertEqual(IE.y, jsons.load(2, IE))
+        self.assertEqual(IE.y, jsons.load('y', IE, use_enum_name=True))
+        self.assertEqual(IE.y, jsons.load(2, IE, use_enum_name=False))
+        with self.assertRaises(DeserializationError):
+            self.assertEqual(IE.y, jsons.load(2, IE, use_enum_name=True))
+        with self.assertRaises(DeserializationError):
+            self.assertEqual(IE.y, jsons.load('y', IE, use_enum_name=False))
+


### PR DESCRIPTION
previously the the primitive handlers grab intenums by default preventing IntEnum being serialized by name, and were serializing instead as int, which is still possible if use_enum_name is False