### PR TITLE
#160 list deserializer propagates fork_inst

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: [
-#             '3.5',  FIXME: time to deprecate?
+            '3.5',
             '3.6',
             '3.7',
             '3.8',
@@ -17,14 +17,14 @@ jobs:
         ]
         os: [
             ubuntu-latest,
-#            macOS-latest,  FIXME: seems to not work at the moment.
+            macOS-latest,
             windows-latest
         ]
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/jsons/deserializers/default_list.py
+++ b/jsons/deserializers/default_list.py
@@ -56,7 +56,7 @@ def _do_load(
     result = []
     for index, elem in enumerate(obj):
         try:
-            result.append(load(elem, cls=cls, tasks=1, **kwargs))
+            result.append(load(elem, cls=cls, tasks=1, fork_inst=fork_inst, **kwargs))
         except DeserializationError as err:
             new_msg = ('Could not deserialize element at index %s. %s' %
                        (index, err.message))

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -184,3 +184,17 @@ class TestList(TestCase):
 
             self.assertIn('500', warn_msg)
             self.assertEqual(999, len(loaded))
+
+    def test_propagation_of_fork_inst(self):
+        class C:
+            def __init__(self, x: int):
+                self.x = x
+
+        def c_deserializer(obj, *_, **__) -> C:
+            return C(obj['x'] * 2)
+
+        fork = jsons.fork(name='fork_inst_propagation')
+        jsons.set_deserializer(c_deserializer, C, fork_inst=fork)
+        cs = jsons.loads('[{"x":2},{"x":3}]', List[C], fork_inst=fork)
+        self.assertEqual(4, cs[0].x)
+        self.assertEqual(6, cs[1].x)


### PR DESCRIPTION
resolves #160
Other container serializers/deserializers don't seem to be affected by this bug, since they seem to already handle fork_inst correctly, though I haven't tested this.