### PR TITLE
add default (de)serializer for Literal values

### DIFF
--- a/jsons/__init__.py
+++ b/jsons/__init__.py
@@ -90,7 +90,7 @@ from datetime import datetime, date, time, timezone, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
 from pathlib import PurePath
-from typing import Union, List, Tuple, Iterable, Optional, DefaultDict, Dict
+from typing import Union, List, Tuple, Iterable, Optional, DefaultDict, Dict, Literal
 from uuid import UUID
 
 from jsons._common_impl import NoneType
@@ -153,6 +153,7 @@ from jsons.deserializers.default_tuple import default_tuple_deserializer
 from jsons.deserializers.default_union import default_union_deserializer
 from jsons.deserializers.default_uuid import default_uuid_deserializer
 from jsons.deserializers.default_zone_info import default_zone_info_deserializer
+from jsons.deserializers.default_literal import default_literal_deserializer
 from jsons.exceptions import (
     JsonsError,
     ValidationError,
@@ -180,6 +181,7 @@ from jsons.serializers.default_tuple import default_tuple_serializer
 from jsons.serializers.default_union import default_union_serializer
 from jsons.serializers.default_uuid import default_uuid_serializer
 from jsons.serializers.default_zone_info import default_zone_info_serializer
+from jsons.serializers.default_literal import default_literal_serializer
 
 KEY_TRANSFORMER_SNAKECASE = snakecase
 KEY_TRANSFORMER_CAMELCASE = camelcase
@@ -249,6 +251,7 @@ __all__ = [
     default_uuid_serializer.__name__,
     default_union_serializer.__name__,
     default_path_serializer.__name__,
+    default_literal_serializer.__name__,
 
     # Deserializers:
     default_list_deserializer.__name__,
@@ -272,6 +275,7 @@ __all__ = [
     default_uuid_deserializer.__name__,
     default_decimal_deserializer.__name__,
     default_path_deserializer.__name__,
+    default_literal_deserializer.__name__,
 ]
 
 set_serializer(default_tuple_serializer, (tuple, Tuple))
@@ -291,6 +295,7 @@ set_serializer(default_uuid_serializer, UUID)
 set_serializer(default_decimal_serializer, Decimal)
 set_serializer(default_union_serializer, (Union, Optional))
 set_serializer(default_path_serializer, PurePath)
+set_serializer(default_literal_serializer, Literal)
 
 set_deserializer(default_list_deserializer, (list, List))
 set_deserializer(default_tuple_deserializer, (tuple, Tuple))
@@ -312,6 +317,7 @@ set_deserializer(default_uuid_deserializer, UUID)
 set_deserializer(default_complex_deserializer, complex)
 set_deserializer(default_decimal_deserializer, Decimal)
 set_deserializer(default_path_deserializer, PurePath)
+set_deserializer(default_literal_deserializer, Literal)
 
 if default_zone_info_serializer and default_zone_info_deserializer:
     from zoneinfo import ZoneInfo

--- a/jsons/deserializers/default_literal.py
+++ b/jsons/deserializers/default_literal.py
@@ -1,0 +1,14 @@
+from typing import Literal, Any, get_args
+
+from jsons.exceptions import DeserializationError
+
+def default_literal_deserializer(obj: Any, cls: Literal, *, strictly_equal_literal: bool = False, **kwargs):
+    for literal_value in get_args(cls):
+        value_equal = obj == literal_value
+        type_equal = type(obj) == type(literal_value)
+        if value_equal and (not strictly_equal_literal or type_equal):
+            break
+    else:
+        err_msg = 'Could not match the object "{}" to the Literal: {}'.format(obj, cls)
+        raise DeserializationError(err_msg, obj, None)
+    return literal_value

--- a/jsons/deserializers/default_literal.py
+++ b/jsons/deserializers/default_literal.py
@@ -2,7 +2,18 @@ from typing import Literal, Any, get_args
 
 from jsons.exceptions import DeserializationError
 
-def default_literal_deserializer(obj: Any, cls: Literal, *, strictly_equal_literal: bool = False, **kwargs):
+def default_literal_deserializer(obj: Any, cls: Literal, *, strictly_equal_literal: bool = False, **_):
+    """
+    Deserialize an object to any matching value of the given Literal. The first
+    successful deserialization is returned.
+    :param obj: The object that needs deserializing.
+    :param cls: The Literal type with values (e.g. Literal[1, 2]).
+    :param strictly_equal_literal: determines whether the type of the value
+    and literal should also be taken into account.
+    :param _: not used.
+    :return: An object of the first value of the Literal that could be
+    deserialized successfully.
+    """
     for literal_value in get_args(cls):
         value_equal = obj == literal_value
         type_equal = type(obj) == type(literal_value)

--- a/jsons/serializers/default_literal.py
+++ b/jsons/serializers/default_literal.py
@@ -1,0 +1,6 @@
+from typing import Literal, Any
+
+from jsons._dump_impl import dump
+
+def default_literal_serializer(obj: Any, cls: Literal, **kwargs):
+    return dump(obj, type(obj), **kwargs)

--- a/jsons/serializers/default_literal.py
+++ b/jsons/serializers/default_literal.py
@@ -3,4 +3,12 @@ from typing import Literal, Any
 from jsons._dump_impl import dump
 
 def default_literal_serializer(obj: Any, cls: Literal, **kwargs):
+    """
+    Serialize an object to its value.
+    :param obj: The object that is to be serialized.
+    :param cls: The Literal type with values (e.g. Union[1, 2]). Not used.
+    :param kwargs: Any keyword arguments that are passed through the
+    serialization process.
+    :return: The serialized object.
+    """
     return dump(obj, type(obj), **kwargs)

--- a/tests/test_literal.py
+++ b/tests/test_literal.py
@@ -1,0 +1,62 @@
+import enum
+from typing import Literal, List, Union
+from unittest import TestCase
+
+import jsons
+from jsons import DeserializationError
+
+
+class TestUnion(TestCase):
+    def test_dump_literal(self):
+        class A:
+            def __init__(self, x: Literal[5]):
+                self.x = x
+        expected = {'x': 5}
+        dumped = jsons.dump(A(5))
+        
+        self.assertDictEqual(expected, dumped)
+
+    def test_load_literal(self):
+        class A:
+            def __init__(self, x: Literal['one', 'two']):
+                self.x = x
+
+        self.assertEqual('one', jsons.load({'x': 'one'}, A).x)
+        self.assertEqual('two', jsons.load({'x': 'two'}, A).x)
+
+        with self.assertRaises(DeserializationError):
+            jsons.load({'x': 'does not match the literal'}, A).x
+
+    def test_load_strictly_equal_literal(self):
+        class ExType(enum.IntEnum):
+            FIRST = 1
+            SECOND = 2
+
+        class A:
+            def __init__(self, x: Literal[ExType.FIRST]):
+                self.x = x
+
+        class B:
+            def __init__(self, x: Literal[1]):
+                self.x = x
+
+        self.assertEqual(ExType.FIRST, jsons.load({'x': 1}, A).x)
+        self.assertEqual(1, jsons.load({'x': 1}, B).x)
+        with self.assertRaises(DeserializationError):
+            jsons.load({'x': 1}, A, strictly_equal_literal=True)
+
+    def test_load_literal_disambiguates_unions(self):
+        class A:
+            def __init__(self, a: int, b: Literal[1]):
+                self.a = a
+                self.b = b
+        class B:
+            def __init__(self, a: int, b: Literal[2]):
+                self.a = a
+                self.b = b
+
+        col = jsons.load([{"a": 0, "b": 2}, {"a": 5, "b": 1}, {"a": 0, "b": 2}, {"a": 3, "b": 1}], List[Union[A, B]])
+        self.assertIsInstance(col[0], B)
+        self.assertIsInstance(col[1], A)
+        self.assertIsInstance(col[2], B)
+        self.assertIsInstance(col[3], A)


### PR DESCRIPTION
I implemented these for a project I'm working on that uses `jsons`, then noticed https://github.com/ramonhagenaars/jsons/issues/170 and figured I may as well see if you like the implementation enough to go with it.

I included the `strictly_equal_literal` as a compromise between correctness and utility.

From https://peps.python.org/pep-0586/#equivalence-of-two-literals
> Two types Literal[v1] and Literal[v2] are equivalent when both of the following conditions are true:
>
> 1. type(v1) == type(v2)
> 2. v1 == v2

I took that to mean that for a value to _really_ match a literal it should match in both type and value. The only problem with that is that I've found it to be very useful to allow `jsons` to "coerce" values that are equal in value into the literal value, the use case that prompted me to implement this actually relies on that behaviour.